### PR TITLE
Move things out of list of active projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Coder, gamer, geek, dad, movie buff and Open Source Community Manager formerly a
 
 ## Current Projects
 
-* [GitHub Actions](https://github.com/lee-dohm?tab=repositories&q=topic%3Aaction&type=source&language=) for myself and my team to use
-* [Discourse extensions and utilities](https://github.com/lee-dohm?tab=repositories&q=topic%3Adiscourse&type=source&language=) mostly for use with the [GitHub Support Community](https://github.community)
 * My ever evolving [dotfiles](https://github.com/lee-dohm/dotfiles)
 * [Custom firmware](https://github.com/lee-dohm/keyboard-firmware) for my collection of mechanical keyboards for every occasion
 
 ## Public Stuff I've Built
 
+* [GitHub Actions](https://github.com/lee-dohm?tab=repositories&q=topic%3Aaction&type=source&language=) for myself and my team to use
+* [Discourse extensions and utilities](https://github.com/lee-dohm?tab=repositories&q=topic%3Adiscourse&type=source&language=) mostly for use with the [GitHub Support Community](https://github.community)
 * [Atom Tweaks website](https://www.atom-tweaks.com)
 
 ## Other stuff I'm proud of contributing to


### PR DESCRIPTION
Since I'm no longer employed by GitHub, my motivation to actively maintain certain projects has evaporated. It's not prudent to set the expectation that these are "current projects," so I've moved them to the list of public stuff I've built instead.

I may pick them up again later and therefore haven't archived them, but 🤷‍♂️ 